### PR TITLE
fix: turn off debug-level printing

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -24,8 +24,6 @@ function deployType(type, cwd, config) {
       config.project_id,
       "--runtime",
       "nodejs10",
-      "--verbosity",
-      "debug",
     ]
     if (type === "PubSub") {
       args.push("--trigger-topic")


### PR DESCRIPTION
debug is so noisy that useful information gets pushed far enough off screen as to be unreachable in some terminals