### PR TITLE
Always create subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-parallel-runner",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Gatsby plugin that allows paralellization of external tasks",
   "keywords": [
     "gatsby"

--- a/src/processor-queue/implementations/google-functions/index.js
+++ b/src/processor-queue/implementations/google-functions/index.js
@@ -39,7 +39,6 @@ class GoogleFunctions {
 
       try {
         if (!noSubscription) {
-          await this._createSubscription()
           await this._createBucket()
         }
       } catch (err) {
@@ -48,6 +47,7 @@ class GoogleFunctions {
         )
       }
 
+      await this._createSubscription()
       await fs.ensureFile(topicCreatedFile)
 
       return this

--- a/src/processor-queue/implementations/google-functions/index.js
+++ b/src/processor-queue/implementations/google-functions/index.js
@@ -39,6 +39,7 @@ class GoogleFunctions {
 
       try {
         if (!noSubscription) {
+          await this._createTopic()
           await this._createBucket()
         }
       } catch (err) {
@@ -85,14 +86,16 @@ class GoogleFunctions {
     this.subscribers.forEach(handler => handler(pubSubMessage))
   }
 
-  async _createSubscription() {
-    // Creates a new subscription
+  async _createTopic() {
     try {
       await this.pubSubClient.createTopic(this.resultTopic)
     } catch (err) {
       log.trace(`Create result topic failed`, err)
     }
+  }
 
+  async _createSubscription() {
+    // Creates a new subscription
     const [subscription] = await this.pubSubClient
       .topic(this.resultTopic)
       .createSubscription(this.subName)


### PR DESCRIPTION
This fixes an issue where we would not create the subscription to pubSub when there was a `topic-created-` file persisted between builds.