### PR TITLE
Update repo / homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby.git",
-    "directory": "packages/gatsby-parallel-runner"
+    "url": "https://github.com/netlify/gatsby-parallel-runner.git",
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-parallel-runner#readme",
+  "homepage": "https://github.com/netlify/gatsby-parallel-runner/",
   "dependencies": {
     "@google-cloud/pubsub": "^0.29.1",
     "@google-cloud/storage": "^4.3.0",


### PR DESCRIPTION
The npm package is still pointing to if this package was a package in the gatsbyjs/gatsby repo, but as it is not, it should be updated to point to this repo so people who try visiting the repo link from npmjs.com, they don't get thrown to a 404 page